### PR TITLE
Change encode return and implement specs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Compile
       run: rebar3 compile
-    # @todo: fix specs.
-    # - name: Run dialyzer
-      # run: rebar3 dialyzer
+    - name: Run dialyzer
+      run: rebar3 dialyzer
     - name: Run tests
       run: rebar3 do ct, eunit

--- a/README.md
+++ b/README.md
@@ -307,8 +307,8 @@ Euneus is the twin brother of [Thoas](https://en.wikipedia.org/wiki/Thoas_(son_o
 ## TODO
 
 - [ ] Improve docs
-- [ ] All specs
-- [X] Embed benchmarks
+- [X] Specs
+- [X] Benchmarks
 - [ ] Test suites
 
 ## Sponsors

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ end
 ## Basic Usage
 
 ```erlang
-1> JSON = euneus:encode_to_binary(#{name => #{english => <<"Charmander">>, japanese => <<"ヒトカゲ"/utf8>>}, caught_at => erlang:timestamp(), type => [fire], profile => #{height => 0.6, weight => 8}, ability => #{0 => <<"Blaze">>, 1 => undefined}}).
-<<"{\"name\":{\"english\":\"Charmander\",\"japanese\":\"ヒトカゲ\"},\"profile\":{\"height\":0.6,\"weight\":8},\"type\":[\"fire\"],\"caught_at\":\"2023-10-24T05:47:04.939Z\",\"ability\":{\"0\":\"Blaze\",\"1\":null}}">>
+1> {ok, JSON} = euneus:encode_to_binary(#{name => #{english => <<"Charmander">>, japanese => <<"ヒトカゲ"/utf8>>}, caught_at => erlang:timestamp(), type => [fire], profile => #{height => 0.6, weight => 8}, ability => #{0 => <<"Blaze">>, 1 => undefined}}).
+{ok, <<"{\"name\":{\"english\":\"Charmander\",\"japanese\":\"ヒトカゲ\"},\"profile\":{\"height\":0.6,\"weight\":8},\"type\":[\"fire\"],\"caught_at\":\"2023-10-24T05:47:04.939Z\",\"ability\":{\"0\":\"Blaze\",\"1\":null}}">>}
 
 2> euneus:decode(JSON).
 {ok,#{<<"ability">> =>
@@ -176,7 +176,7 @@ EncodeOpts = #{
 },
 Data = #{<<"foo">> => bar, ipv4 => {127, 0, 0, 1}, none => undefined},
 euneus:encode_to_binary(Data, EncodeOpts).
-%% <<"{\"bar\":\"bar\",\"ipv4\":\"127.0.0.1\",\"none\":null}">>
+%% {ok, <<"{\"bar\":\"bar\",\"ipv4\":\"127.0.0.1\",\"none\":null}">>}
 ```
 
 ### Decode

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ EncodeOpts = #{
                     euneus_encoder:escape_binary(IpBin, Opts)
             end;
         (Term, Opts) ->
-            euneus_encoder:unsupported_type_error(Term, Opts)
+            euneus_encoder:throw_unsupported_type_error(Term, Opts)
     end
 },
 Data = #{<<"foo">> => bar, ipv4 => {127, 0, 0, 1}, none => undefined},

--- a/euneus_bench/script/helper.exs
+++ b/euneus_bench/script/helper.exs
@@ -18,8 +18,8 @@ defmodule EuneusBench.Helper do
       memory_time: Map.get(opts, :memory_time, 1),
       inputs: inputs,
       formatters: [
+        Benchee.Formatters.Console,
         {Benchee.Formatters.HTML, file: Path.expand("../tmp/#{label}.html", __DIR__)},
-        Benchee.Formatters.Console
       ]
     )
   end

--- a/src/euneus.erl
+++ b/src/euneus.erl
@@ -23,47 +23,52 @@
 -export([ encode_to_binary/1, encode_to_binary/2 ]).
 -export([ decode/1, decode/2 ]).
 
--spec encode(Term) -> Return when
-    Term :: term(),
-    Return :: iolist().
+-spec encode(Input) -> Return when
+    Input :: euneus_encoder:input(),
+    Return :: euneus_encoder:result().
 
-encode(Term) ->
-    encode(Term, #{}).
+encode(Input) ->
+    encode(Input, #{}).
 
--spec encode(Term, Opts) -> Return when
-    Term :: term(),
+-spec encode(Input, Opts) -> Return when
+    Input :: euneus_encoder:input(),
     Opts :: euneus_encoder:options(),
-    Return :: iolist().
+    Return :: euneus_encoder:result().
 
-encode(Term, Opts) ->
-    euneus_encoder:encode(Term, Opts).
+encode(Input, Opts) ->
+    euneus_encoder:encode(Input, Opts).
 
--spec encode_to_binary(Term) -> Return when
-    Term :: term(),
-    Return :: binary().
+-spec encode_to_binary(Input) -> Return when
+    Input :: euneus_encoder:input(),
+    Return :: {ok, binary()} | {error, euneus_encoder:error_reason()}.
 
-encode_to_binary(Term) ->
-    encode_to_binary(Term, #{}).
+encode_to_binary(Input) ->
+    encode_to_binary(Input, #{}).
 
--spec encode_to_binary(Term, Opts) -> Return when
-    Term :: term(),
+-spec encode_to_binary(Input, Opts) -> Return when
+    Input :: euneus_encoder:input(),
     Opts :: euneus_encoder:options(),
-    Return :: binary().
+    Return :: {ok, binary()} | {error, euneus_encoder:error_reason()}.
 
-encode_to_binary(Term, Opts) ->
-    iolist_to_binary(encode(Term, Opts)).
+encode_to_binary(Input, Opts) ->
+    case encode(Input, Opts) of
+        {ok, Result} ->
+            {ok, iolist_to_binary(Result)};
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
--spec decode(Bin) -> Result when
-    Bin :: binary(),
-    Result :: term().
+-spec decode(Input) -> Result when
+    Input :: euneus_decoder:input(),
+    Result :: euneus_decoder:result().
 
-decode(Bin) ->
-    decode(Bin, #{}).
+decode(Input) ->
+    decode(Input, #{}).
 
--spec decode(Bin, Opts) -> Result when
-    Bin :: binary(),
+-spec decode(Input, Opts) -> Result when
+    Input :: euneus_decoder:input(),
     Opts :: euneus_decoder:options(),
-    Result :: term().
+    Result :: euneus_decoder:result().
 
-decode(Bin, Opts) ->
-    euneus_decoder:decode(Bin, Opts).
+decode(Input, Opts) ->
+    euneus_decoder:decode(Input, Opts).

--- a/src/euneus.erl
+++ b/src/euneus.erl
@@ -17,7 +17,7 @@
 %% limitations under the License.
 -module(euneus).
 
--compile({inline, [ encode/1, encode_to_binary/1, encode_to_binary/2, decode/1 ]}).
+-compile({inline, [ encode/2, encode_to_binary/2, decode/2 ]}).
 
 -export([ encode/1, encode/2 ]).
 -export([ encode_to_binary/1, encode_to_binary/2 ]).

--- a/src/euneus.erl
+++ b/src/euneus.erl
@@ -23,20 +23,47 @@
 -export([ encode_to_binary/1, encode_to_binary/2 ]).
 -export([ decode/1, decode/2 ]).
 
+-spec encode(Term) -> Return when
+    Term :: term(),
+    Return :: iolist().
+
 encode(Term) ->
     encode(Term, #{}).
+
+-spec encode(Term, Opts) -> Return when
+    Term :: term(),
+    Opts :: euneus_encoder:options(),
+    Return :: iolist().
 
 encode(Term, Opts) ->
     euneus_encoder:encode(Term, Opts).
 
+-spec encode_to_binary(Term) -> Return when
+    Term :: term(),
+    Return :: binary().
+
 encode_to_binary(Term) ->
     encode_to_binary(Term, #{}).
+
+-spec encode_to_binary(Term, Opts) -> Return when
+    Term :: term(),
+    Opts :: euneus_encoder:options(),
+    Return :: binary().
 
 encode_to_binary(Term, Opts) ->
     iolist_to_binary(encode(Term, Opts)).
 
+-spec decode(Bin) -> Result when
+    Bin :: binary(),
+    Result :: term().
+
 decode(Bin) ->
     decode(Bin, #{}).
+
+-spec decode(Bin, Opts) -> Result when
+    Bin :: binary(),
+    Opts :: euneus_decoder:options(),
+    Result :: term().
 
 decode(Bin, Opts) ->
     euneus_decoder:decode(Bin, Opts).

--- a/src/euneus_decoder.erl
+++ b/src/euneus_decoder.erl
@@ -36,7 +36,7 @@
 
 -export([ decode/2 ]).
 
--export_type([ options/0 ]).
+-export_type([ input/0, options/0, result/0, error_reason/0 ]).
 
 % Use integers instead of atoms to take advantage of the jump table optimization.
 -define(terminate, 0).
@@ -46,20 +46,30 @@
 
 -define(is_number(X), X >= $0, X =< $9).
 
--type normalize(Type) :: fun((Type, options()) -> term()).
+-type input() :: binary().
 
 -type options() :: #{
     null_term => term(),
-    normalize_key => normalize(binary()),
-    normalize_value => normalize(binary()),
-    normalize_array => normalize(list()),
-    normalize_object => normalize(map())
+    normalize_key => normalize_fun(Input :: binary()),
+    normalize_value => normalize_fun(Input :: binary()),
+    normalize_array => normalize_fun(Input :: list()),
+    normalize_object => normalize_fun(Input :: map())
 }.
 
+-type position() :: non_neg_integer().
+
+-type error_reason() :: unexpected_end_of_input
+                      | {unexpected_byte, binary(), position()}
+                      | {unexpected_sequence, binary(), position()}.
+
+-type result() :: {ok, term()} | {error, error_reason()}.
+
+-type normalize_fun(Input) :: fun((Input, options()) -> term()).
+
 -spec decode(Bin, Opts) -> Result when
-    Bin :: binary(),
+    Bin :: input(),
     Opts :: options(),
-    Result :: term().
+    Result :: result().
 
 decode(Bin, Opts) when is_binary(Bin) andalso is_map(Opts) ->
     try

--- a/src/euneus_decoder.erl
+++ b/src/euneus_decoder.erl
@@ -519,7 +519,7 @@ escapeu_2(<<_/bitstring>> = Rest, Opts, Input, Skip, Stack, Acc, Last, X) ->
     string(Rest, Opts, Input, Skip + 6, Stack, D, 0).
 
 number(<<Byte/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Len)
-  when Byte >= $0 andalso Byte =< $9 ->
+  when ?is_number(Byte) ->
     number(Rest, Opts, Input, Skip, Stack, Len + 1);
 number(<<$./integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Len) ->
     number_frac(Rest, Opts, Input, Skip, Stack, Len + 1);
@@ -532,7 +532,7 @@ number(<<Rest/bitstring>>, Opts, Input, Skip, Stack, Len) ->
     continue(Rest, Opts, Input, Skip + Len, Stack, Int).
 
 number_exp(<<Byte/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Len)
-  when Byte >= $0 andalso Byte =< $9 ->
+  when ?is_number(Byte) ->
     number_exp_cont(Rest, Opts, Input, Skip, Stack, Len + 1);
 number_exp(<<Byte/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Len)
   when Byte =:= $+ orelse Byte =:= $- ->
@@ -541,7 +541,7 @@ number_exp(<<_Rest/bitstring>>, _Opts, Input, Skip, _Stack, Len) ->
     throw_error(Input, Skip + Len).
 
 number_exp_cont(<<Byte/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Len)
-  when Byte >= $0 andalso Byte =< $9 ->
+  when ?is_number(Byte) ->
     number_exp_cont(Rest, Opts, Input, Skip, Stack, Len + 1);
 number_exp_cont(<<Rest/bitstring>>, Opts, Input, Skip, Stack, Len) ->
     Token = binary_part(Input, Skip, Len),
@@ -549,7 +549,7 @@ number_exp_cont(<<Rest/bitstring>>, Opts, Input, Skip, Stack, Len) ->
     continue(Rest, Opts, Input, Skip + Len, Stack, Float).
 
 number_exp_cont(<<Byte/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Prefix, Len)
-  when Byte >= $0 andalso Byte =< $9 ->
+  when ?is_number(Byte) ->
     number_exp_cont(Rest, Opts, Input, Skip, Stack, Prefix, Len + 1);
 number_exp_cont(<<Rest/bitstring>>, Opts, Input, Skip, Stack, Prefix, Len) ->
     Suffix = binary_part(Input, Skip, Len),
@@ -562,7 +562,7 @@ number_exp_cont(<<Rest/bitstring>>, Opts, Input, Skip, Stack, Prefix, Len) ->
     continue(Rest, Opts, Input, FinalSkip, Stack, Float).
 
 number_exp_copy(<<Byte/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Prefix)
-  when Byte >= $0 andalso Byte =< $9 ->
+  when ?is_number(Byte) ->
     number_exp_cont(Rest, Opts, Input, Skip, Stack, Prefix, 1);
 number_exp_copy(<<Byte/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Prefix)
   when Byte =:= $+ orelse Byte =:= $- ->
@@ -571,25 +571,25 @@ number_exp_copy(<<_Rest/bitstring>>, _Opts, Input, Skip, _Stack, _Prefix) ->
     throw_error(Input, Skip).
 
 number_exp_sign(<<Byte/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Len)
-  when Byte >= $0 andalso Byte =< $9 ->
+  when ?is_number(Byte) ->
     number_exp_cont(Rest, Opts, Input, Skip, Stack, Len + 1);
 number_exp_sign(<<_Rest/bitstring>>, _Opts, Input, Skip, _Stack, Len) ->
     throw_error(Input, Skip + Len).
 
 number_exp_sign(<<Byte/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Prefix, Len)
-  when Byte >= $0 andalso Byte =< $9 ->
+  when ?is_number(Byte) ->
     number_exp_cont(Rest, Opts, Input, Skip, Stack, Prefix, Len + 1);
 number_exp_sign(<<_Rest/bitstring>>, _Opts, Input, Skip, _Stack, _Prefix, Len) ->
     throw_error(Input, Skip + Len).
 
 number_frac(<<Byte/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Len)
-  when Byte >= $0 andalso Byte =< $9 ->
+  when ?is_number(Byte) ->
     number_frac_cont(Rest, Opts, Input, Skip, Stack, Len + 1);
 number_frac(<<_Rest/bitstring>>, _Opts, Input, Skip, _Stack, Len) ->
     throw_error(Input, Skip + Len).
 
 number_frac_cont(<<Byte/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Len)
-  when Byte >= $0 andalso Byte =< $9 ->
+  when ?is_number(Byte) ->
     number_frac_cont(Rest, Opts, Input, Skip, Stack, Len + 1);
 number_frac_cont(<<E/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Len)
   when E =:= $e orelse E =:= $E ->
@@ -602,7 +602,7 @@ number_frac_cont(<<Rest/bitstring>>, Opts, Input, Skip, Stack, Len) ->
 number_minus(<<48/integer,Rest/bitstring>>, Opts, Input, Skip, Stack) ->
     number_zero(Rest, Opts, Input, Skip, Stack, 2);
 number_minus(<<Byte/integer,Rest/bitstring>>, Opts, Input, Skip, Stack)
-  when Byte >= $0 andalso Byte =< $9 ->
+  when ?is_number(Byte) ->
     number(Rest, Opts, Input, Skip, Stack, 2);
 number_minus(<<_Rest/bitstring>>, _Opts, Input, Skip, _Stack) ->
     throw_error(Input, Skip + 1).

--- a/src/euneus_decoder.erl
+++ b/src/euneus_decoder.erl
@@ -618,17 +618,13 @@ number_zero(<<Rest/bitstring>>, Opts, Input, Skip, Stack, Len) ->
 object(<<H/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Value)
   when H =:= 32; H =:= 9; H =:= 10; H =:= 13 ->
     object(Rest, Opts, Input, Skip + 1, Stack, Value);
-object(<<44/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Value) ->
-    Skip2 = Skip + 1,
-    [Key, Acc | Stack2] = Stack,
-    Acc2 = [{Key, Value} | Acc],
-    key(Rest, Opts, Input, Skip2, [Acc2 | Stack2]);
-object(<<125/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Value) ->
-    Skip2 = Skip + 1,
-    [Key, Acc2 | Stack2] = Stack,
-    Final = [{Key, Value} | Acc2],
-    Map = normalize_object(Opts, maps:from_list(Final)),
-    continue(Rest, Opts, Input, Skip2, Stack2, Map);
+object(<<44/integer,Rest/bitstring>>, Opts, Input, Skip, [Key, Acc0 | Stack], Value) ->
+    Acc = [{Key, Value} | Acc0],
+    key(Rest, Opts, Input, Skip + 1, [Acc | Stack]);
+object(<<125/integer,Rest/bitstring>>, Opts, Input, Skip, [Key, Acc0 | Stack], Value) ->
+    Acc = [{Key, Value} | Acc0],
+    Map = normalize_object(Opts, maps:from_list(Acc)),
+    continue(Rest, Opts, Input, Skip + 1, Stack, Map);
 object(<<_/integer,_/bitstring>>, _Opts, Input, Skip, _Stack, _Value) ->
     throw_error(Input, Skip);
 object(<<_/bitstring>>, _Opts, Input, Skip, _Stack, _Value) ->

--- a/src/euneus_decoder.erl
+++ b/src/euneus_decoder.erl
@@ -655,12 +655,8 @@ normalize_array(#{normalize_array := Normalize} = Opts, Array) ->
 normalize_array(_Opts, Array) ->
     Array.
 
-empty_array(<<Rest/bitstring>>, Opts, Input, Skip, [?array, [] | Stack]) ->
-    continue(Rest, Opts, Input, Skip, Stack, []);
-empty_array(<<_/integer,_/bitstring>>, _Opts, Input, Skip, _Stack) ->
-    throw_error(Input, Skip - 1);
-empty_array(<<_/bitstring>>, _Opts, Input, Skip, _Stack) ->
-    empty_error(Input, Skip).
+empty_array(Rest, Opts, Input, Skip, [?array, [] | Stack]) ->
+    continue(Rest, Opts, Input, Skip, Stack, []).
 
 continue(Rest, Opts, Input, Skip, [?key | Stack], Value) ->
     key(Rest, Opts, Input, Skip, Stack, Value);

--- a/src/euneus_decoder.erl
+++ b/src/euneus_decoder.erl
@@ -178,11 +178,11 @@ string(<<_/bitstring>>, _Opts, Input, Skip, _Stack, Len) ->
 
 string(<<$"/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Acc, Len) ->
     Last = binary_part(Input, Skip, Len),
-    String = iolist_to_binary([Acc | Last]),
+    String = iolist_to_binary([Acc, Last]),
     continue(Rest, Opts, Input, Skip + Len + 1, Stack, String);
 string(<<$\\/integer,Rest/bitstring>>, Opts, Input, Skip, Stack, Acc, Len) ->
     Part = binary_part(Input, Skip, Len),
-    escape(Rest, Opts, Input, Skip + Len, Stack, [Acc | Part]);
+    escape(Rest, Opts, Input, Skip + Len, Stack, [Acc, Part]);
 string(<<H/integer,_/bitstring>>, _Opts, Input, Skip, _Stack, _Acc, _Len)
   when H < 32 ->
     throw_error(Input, Skip);
@@ -473,7 +473,7 @@ escape_surrogate(<<92/integer, 117/integer, Int1:16/integer, Int2:16/integer, Re
         _ -> token_error(Input, Skip, 12)
     end,
     Y = X band 3 bsl 8 + Last,
-    Acc = [Acc0 | <<(Hi + Y)/utf8>>],
+    Acc = [Acc0, <<(Hi + Y)/utf8>>],
     string(Rest, Opts, Input, Skip + 12, Stack, Acc, 0);
 escape_surrogate(<<_Rest/bitstring>>, _Opts, Input, Skip, _Stack, _Acc, _Hi) ->
     throw_error(Input, Skip + 6).

--- a/src/euneus_encoder.erl
+++ b/src/euneus_encoder.erl
@@ -29,6 +29,10 @@
 ]}).
 -compile({inline_size, 100}).
 
+% By default, encode_unhandled/2 will raise unsupported_type exception,
+% so it is a function without a local return.
+-dialyzer({no_return, [parse_opts/1, encode_unhandled/2]}).
+
 -export([ encode/2 ]).
 -export([
     encode_binary/2, encode_atom/2, encode_integer/2, encode_float/2,

--- a/src/euneus_encoder.erl
+++ b/src/euneus_encoder.erl
@@ -219,7 +219,7 @@ escape_json(Bin) ->
 
 escape_json(<<Byte/integer, Rest/bitstring>>, Acc0, Input, Skip)
     when Byte < 32; Byte =:= $\"; Byte =:= $\\ ->
-    Acc = [Acc0 | escape_byte(Byte)],
+    Acc = [Acc0, escape_byte(Byte)],
     escape_json(Rest, Acc, Input, Skip+1);
 escape_json(<<Byte/integer, Rest/bitstring>>, Acc, Input, Skip)
     when Byte < 128 ->
@@ -240,7 +240,7 @@ escape_json(<<Byte/integer, _Rest/bitstring>>, _Acc, Input, _Skip) ->
 escape_json_chunk(<<Byte/integer, Rest/bitstring>>, Acc0, Input, Skip, Len)
     when Byte < 32; Byte =:= $\"; Byte =:= $\\ ->
     Part = binary_part(Input, Skip, Len),
-    Acc = [Acc0, Part | escape_byte(Byte)],
+    Acc = [Acc0, Part, escape_byte(Byte)],
     escape_json(Rest, Acc, Input, Skip+Len+1);
 escape_json_chunk(<<Byte/integer, Rest/bitstring>>, Acc, Input, Skip, Len)
     when Byte < 128 ->
@@ -256,8 +256,7 @@ escape_json_chunk(<<_Char/utf8, Rest/bitstring>>, Acc, Input, Skip, Len) ->
 escape_json_chunk(<<>>, [], Input, Skip, Len) ->
     binary_part(Input, Skip, Len);
 escape_json_chunk(<<>>, Acc, Input, Skip, Len) ->
-    Part = binary_part(Input, Skip, Len),
-    [Acc | Part];
+    [Acc, binary_part(Input, Skip, Len)];
 escape_json_chunk(<<Byte/integer, _Rest/bitstring>>, _Acc, Input, _Skip, _Len) ->
     invalid_byte_error(Byte, Input).
 
@@ -266,7 +265,7 @@ escape_html(Bin) ->
 
 escape_html(<<Byte/integer, Rest/bitstring>>, Acc0, Input, Skip)
     when Byte < 33; Byte =:= $\"; Byte =:= $/; Byte =:= $\\ ->
-    Acc = [Acc0 | escape_byte(Byte)],
+    Acc = [Acc0, escape_byte(Byte)],
     escape_html(Rest, Acc, Input, Skip+1);
 escape_html(<<Byte/integer, Rest/bitstring>>, Acc, Input, Skip)
     when Byte < 128 ->
@@ -275,10 +274,10 @@ escape_html(<<Char/utf8, Rest/bitstring>>, Acc, Input, Skip)
     when Char < 2048 ->
     escape_html_chunk(Rest, Acc, Input, Skip, 2);
 escape_html(<<8232/utf8, Rest/bitstring>>, Acc0, Input, Skip) ->
-    Acc = [Acc0 | <<"\\u2028">>],
+    Acc = [Acc0, <<"\\u2028">>],
     escape_html(Rest, Acc, Input, Skip+3);
 escape_html(<<8233/utf8, Rest/bitstring>>, Acc0, Input, Skip) ->
-    Acc = [Acc0 | <<"\\u2029">>],
+    Acc = [Acc0, <<"\\u2029">>],
     escape_html(Rest, Acc, Input, Skip+3);
 escape_html(<<Char/utf8, Rest/bitstring>>, Acc, Input, Skip)
     when Char < 65536 ->
@@ -293,7 +292,7 @@ escape_html(<<Byte/integer, _Rest/bitstring>>, _Acc, Input, _Skip) ->
 escape_html_chunk(<<Byte/integer, Rest/bitstring>>, Acc, Input, Skip, Len)
     when Byte < 33; Byte =:= $\"; Byte =:= $/; Byte =:= $\\ ->
     Part = binary_part(Input, Skip, Len),
-    Acc2 = [Acc, Part | escape_byte(Byte)],
+    Acc2 = [Acc, Part, escape_byte(Byte)],
     escape_html(Rest, Acc2, Input, Skip+Len+1);
 escape_html_chunk(<<Byte/integer, Rest/bitstring>>, Acc, Input, Skip, Len)
     when Byte < 128 ->
@@ -303,11 +302,11 @@ escape_html_chunk(<<Char/utf8, Rest/bitstring>>, Acc, Input, Skip, Len)
     escape_html_chunk(Rest, Acc, Input, Skip, Len+2);
 escape_html_chunk(<<8232/utf8, Rest/bitstring>>, Acc, Input, Skip, Len) ->
     Part = binary_part(Input, Skip, Len),
-    Acc2 = [Acc, Part | <<"\\u2028">>],
+    Acc2 = [Acc, Part, <<"\\u2028">>],
     escape_html(Rest, Acc2, Input, Skip+Len+3);
 escape_html_chunk(<<8233/utf8, Rest/bitstring>>, Acc, Input, Skip, Len) ->
     Part = binary_part(Input, Skip, Len),
-    Acc2 = [Acc, Part | <<"\\u2029">>],
+    Acc2 = [Acc, Part, <<"\\u2029">>],
     escape_html(Rest, Acc2, Input, Skip+Len+3);
 escape_html_chunk(<<Char/utf8, Rest/bitstring>>, Acc, Input, Skip, Len)
     when Char < 65536 ->
@@ -317,8 +316,7 @@ escape_html_chunk(<<_Char/utf8, Rest/bitstring>>, Acc, Input, Skip, Len) ->
 escape_html_chunk(<<>>, [], Input, Skip, Len) ->
     binary_part(Input, Skip, Len);
 escape_html_chunk(<<>>, Acc, Input, Skip, Len) ->
-    Part = binary_part(Input, Skip, Len),
-    [Acc | Part];
+    [Acc, binary_part(Input, Skip, Len)];
 escape_html_chunk(<<Byte/integer, _Rest/bitstring>>, _Acc, Input, _Skip, _Len) ->
     invalid_byte_error(Byte, Input).
 
@@ -327,7 +325,7 @@ escape_js(Bin) ->
 
 escape_js(<<Byte/integer, Rest/bitstring>>, Acc0, Input, Skip)
     when Byte < 32; Byte =:= $\"; Byte =:= $\\ ->
-    Acc = [Acc0 | escape_byte(Byte)],
+    Acc = [Acc0, escape_byte(Byte)],
     escape_js(Rest, Acc, Input, Skip+1);
 escape_js(<<Byte/integer, Rest/bitstring>>, Acc, Input, Skip)
     when Byte < 128 ->
@@ -336,10 +334,10 @@ escape_js(<<Char/utf8, Rest/bitstring>>, Acc, Input, Skip)
     when Char < 2048 ->
     escape_js_chunk(Rest, Acc, Input, Skip, 2);
 escape_js(<<8232/utf8, Rest/bitstring>>, Acc0, Input, Skip) ->
-    Acc = [Acc0 | <<"\\u2028">>],
+    Acc = [Acc0, <<"\\u2028">>],
     escape_js(Rest, Acc, Input, Skip+3);
 escape_js(<<8233/utf8, Rest/bitstring>>, Acc0, Input, Skip) ->
-    Acc = [Acc0 | <<"\\u2029">>],
+    Acc = [Acc0, <<"\\u2029">>],
     escape_js(Rest, Acc, Input, Skip+3);
 escape_js(<<Char/utf8, Rest/bitstring>>, Acc, Input, Skip)
     when Char < 65536 ->
@@ -354,7 +352,7 @@ escape_js(<<Byte/integer, _Rest/bitstring>>, _Acc, Input, _Skip) ->
 escape_js_chunk(<<Byte/integer, Rest/bitstring>>, Acc0, Input, Skip, Len)
     when Byte < 32; Byte =:= $\"; Byte =:= $\\ ->
     Part = binary_part(Input, Skip, Len),
-    Acc = [Acc0, Part | escape_byte(Byte)],
+    Acc = [Acc0, Part, escape_byte(Byte)],
     escape_js(Rest, Acc, Input, Skip+Len+1);
 escape_js_chunk(<<Byte/integer, Rest/bitstring>>, Acc, Input, Skip, Len)
     when Byte < 128 ->
@@ -364,11 +362,11 @@ escape_js_chunk(<<Char/utf8, Rest/bitstring>>, Acc, Input, Skip, Len)
     escape_js_chunk(Rest, Acc, Input, Skip, Len+2);
 escape_js_chunk(<<8232/utf8, Rest/bitstring>>, Acc0, Input, Skip, Len) ->
     Part = binary_part(Input, Skip, Len),
-    Acc = [Acc0, Part | <<"\\u2028">>],
+    Acc = [Acc0, Part, <<"\\u2028">>],
     escape_js(Rest, Acc, Input, Skip+Len+3);
 escape_js_chunk(<<8233/utf8, Rest/bitstring>>, Acc0, Input, Skip, Len) ->
     Part = binary_part(Input, Skip, Len),
-    Acc = [Acc0, Part | <<"\\u2029">>],
+    Acc = [Acc0, Part, <<"\\u2029">>],
     escape_js(Rest, Acc, Input, Skip+Len+3);
 escape_js_chunk(<<Char/utf8, Rest/bitstring>>, Acc, Input, Skip, Len)
     when Char < 65536 ->
@@ -378,8 +376,7 @@ escape_js_chunk(<<_Char/utf8, Rest/bitstring>>, Acc, Input, Skip, Len) ->
 escape_js_chunk(<<>>, [], Input, Skip, Len) ->
     binary_part(Input, Skip, Len);
 escape_js_chunk(<<>>, Acc, Input, Skip, Len) ->
-    Part = binary_part(Input, Skip, Len),
-    [Acc | Part];
+    [Acc, binary_part(Input, Skip, Len)];
 escape_js_chunk(<<Byte/integer, _Rest/bitstring>>, _Acc, Input, _Skip, _Len) ->
     invalid_byte_error(Byte, Input).
 
@@ -388,34 +385,34 @@ escape_unicode(Bin) ->
 
 escape_unicode(<<Byte/integer, Rest/bitstring>>, Acc0, Input, Skip)
   when Byte < 32; Byte =:= $\"; Byte =:= $\\ ->
-    Acc = [Acc0 | escape_byte(Byte)],
+    Acc = [Acc0, escape_byte(Byte)],
     escape_unicode(Rest, Acc, Input, Skip+1);
 escape_unicode(<<Byte/integer, Rest/bitstring>>, Acc, Input, Skip)
   when Byte < 128 ->
     escape_unicode_chunk(Rest, Acc, Input, Skip, 1);
 escape_unicode(<<Char/utf8, Rest/bitstring>>, Acc0, Input, Skip)
   when Char < 256 ->
-    Acc = [Acc0, <<"\\u00">> | integer_to_list(Char, 16)],
+    Acc = [Acc0, <<"\\u00">>, integer_to_binary(Char, 16)],
     escape_unicode(Rest, Acc, Input, Skip+2);
 escape_unicode(<<Char/utf8, Rest/bitstring>>, Acc0, Input, Skip)
   when Char < 2048 ->
-    Acc = [Acc0, <<"\\u0">> | integer_to_list(Char, 16)],
+    Acc = [Acc0, <<"\\u0">>, integer_to_binary(Char, 16)],
     escape_unicode(Rest, Acc, Input, Skip+2);
 escape_unicode(<<Char/utf8, Rest/bitstring>>, Acc0, Input, Skip)
   when Char < 4096 ->
-    Acc = [Acc0, <<"\\u0">> | integer_to_list(Char, 16)],
+    Acc = [Acc0, <<"\\u0">>, integer_to_binary(Char, 16)],
     escape_unicode(Rest, Acc, Input, Skip+3);
 escape_unicode(<<Char/utf8, Rest/bitstring>>, Acc0, Input, Skip)
   when Char < 65536 ->
-    Acc = [Acc0, <<"\\u">> | integer_to_list(Char, 16)],
+    Acc = [Acc0, <<"\\u">>, integer_to_binary(Char, 16)],
     escape_unicode(Rest, Acc, Input, Skip+3);
 escape_unicode(<<Char0/utf8, Rest/bitstring>>, Acc0, Input, Skip) ->
     Char = Char0 - 65536,
     Acc = [ Acc0
           , <<"\\uD">>
-          , integer_to_list(2048 bor (Char bsr 10), 16)
+          , integer_to_binary(2048 bor (Char bsr 10), 16)
           , <<"\\uD">>
-          | integer_to_list(3072 bor Char band 1023, 16)
+          , integer_to_binary(3072 bor Char band 1023, 16)
           ],
     escape_unicode(Rest, Acc, Input, Skip+4);
 escape_unicode(<<>>, Acc, _Input, _Skip) ->
@@ -426,7 +423,7 @@ escape_unicode(<<Byte/integer, _Rest/bitstring>>, _Acc, Input, _Skip) ->
 escape_unicode_chunk(<<Byte/integer, Rest/bitstring>>, Acc0, Input, Skip, Len)
   when Byte < 32; Byte =:= $\"; Byte =:= $\\ ->
     Part = binary_part(Input, Skip, Len),
-    Acc = [Acc0, Part | escape_byte(Byte)],
+    Acc = [Acc0, Part, escape_byte(Byte)],
     escape_unicode(Rest, Acc, Input, Skip+Len+1);
 escape_unicode_chunk(<<Byte/integer, Rest/bitstring>>, Acc, Input, Skip, Len)
   when Byte < 128 ->
@@ -434,22 +431,22 @@ escape_unicode_chunk(<<Byte/integer, Rest/bitstring>>, Acc, Input, Skip, Len)
 escape_unicode_chunk(<<Char/utf8, Rest/bitstring>>, Acc0, Input, Skip, Len)
   when Char < 256 ->
     Part = binary_part(Input, Skip, Len),
-    Acc = [Acc0, Part, <<"\\u00">> | integer_to_list(Char, 16)],
+    Acc = [Acc0, Part, <<"\\u00">>, integer_to_binary(Char, 16)],
     escape_unicode(Rest, Acc, Input, Skip+Len+2);
 escape_unicode_chunk(<<Char/utf8, Rest/bitstring>>, Acc0, Input, Skip, Len)
   when Char < 2048 ->
     Part = binary_part(Input, Skip, Len),
-    Acc = [Acc0, Part, <<"\\u0">> | integer_to_list(Char, 16)],
+    Acc = [Acc0, Part, <<"\\u0">>, integer_to_binary(Char, 16)],
     escape_unicode(Rest, Acc, Input, Skip+Len+2);
 escape_unicode_chunk(<<Char/utf8, Rest/bitstring>>, Acc0, Input, Skip, Len)
   when Char < 4096 ->
     Part = binary_part(Input, Skip, Len),
-    Acc = [Acc0, Part, <<"\\u0">> | integer_to_list(Char, 16)],
+    Acc = [Acc0, Part, <<"\\u0">>, integer_to_binary(Char, 16)],
     escape_unicode(Rest, Acc, Input, Skip+Len+3);
 escape_unicode_chunk(<<Char/utf8, Rest/bitstring>>, Acc0, Input, Skip, Len)
   when Char < 65536 ->
     Part = binary_part(Input, Skip, Len),
-    Acc = [Acc0, Part, <<"\\u">> | integer_to_list(Char, 16)],
+    Acc = [Acc0, Part, <<"\\u">>, integer_to_binary(Char, 16)],
     escape_unicode(Rest, Acc, Input, Skip+Len+3);
 escape_unicode_chunk(<<Char0/utf8, Rest/bitstring>>, Acc0, Input, Skip, Len) ->
     Char = Char0 - 65536,
@@ -457,16 +454,15 @@ escape_unicode_chunk(<<Char0/utf8, Rest/bitstring>>, Acc0, Input, Skip, Len) ->
     Acc = [ Acc0
           , Part
           , <<"\\uD">>
-          , integer_to_list(2048 bor (Char bsr 10), 16)
+          , integer_to_binary(2048 bor (Char bsr 10), 16)
           , <<"\\uD">>
-          | integer_to_list(3072 bor Char band 1023, 16)
+          , integer_to_binary(3072 bor Char band 1023, 16)
           ],
     escape_unicode(Rest, Acc, Input, Skip+Len+4);
 escape_unicode_chunk(<<>>, [], Input, Skip, Len) ->
     binary_part(Input, Skip, Len);
 escape_unicode_chunk(<<>>, Acc, Input, Skip, Len) ->
-    Part = binary_part(Input, Skip, Len),
-    [Acc | Part];
+    [Acc, binary_part(Input, Skip, Len)];
 escape_unicode_chunk(<<Byte/integer, _Rest/bitstring>>, _Acc, Input, _Skip, _Len) ->
     invalid_byte_error(Byte, Input).
 

--- a/src/euneus_encoder.erl
+++ b/src/euneus_encoder.erl
@@ -43,8 +43,32 @@
 -export([ escape_binary/2, escape_byte/1 ]).
 -export([ escape_json/1, escape_html/1, escape_js/1, escape_unicode/1 ]).
 
+-export_type([ options/0 ]).
+
 -define(min(X, Min), is_integer(X) andalso X >= Min).
 -define(range(X, Min, Max), is_integer(X) andalso X >= Min andalso X =< Max).
+
+-type encode(Type) :: fun((Type, options()) -> iolist()).
+-type escape(Type) :: fun((Type, options()) -> iolist()).
+
+-type options() :: #{
+    null_terms => list(),
+    encode_binary => encode(binary()),
+    encode_atom => encode(atom()),
+    encode_integer => encode(integer()),
+    encode_float => encode(float()),
+    encode_list => encode(list()),
+    encode_map => encode(map()),
+    encode_datetime => encode(calendar:datetime()),
+    encode_timestamp => encode(erlang:timestamp()),
+    encode_unhandled => encode(term()),
+    escape_binary => escape(binary())
+}.
+
+-spec encode(Term, Opts) -> Return when
+    Term :: term(),
+    Opts :: options(),
+    Return :: iolist().
 
 encode(Term, Opts) ->
     value(Term, parse_opts(Opts)).

--- a/src/euneus_encoder.erl
+++ b/src/euneus_encoder.erl
@@ -137,27 +137,27 @@ encode_float(Float, _Opts) ->
     float_to_binary(Float, [short]).
 
 encode_list([H | T], Opts) ->
-    [$[, value(H, Opts) | do_encode_list_loop(T, Opts)];
+    [$[, value(H, Opts), do_encode_list_loop(T, Opts)];
 encode_list([], _Opts) ->
     <<"[]">>.
 
 do_encode_list_loop([H | T], Opts) ->
-    [$,, value(H, Opts) | do_encode_list_loop(T, Opts)];
+    [$,, value(H, Opts), do_encode_list_loop(T, Opts)];
 do_encode_list_loop([], _Opts) ->
-    [$]].
+    $].
 
 encode_map(Map, Opts) ->
     do_encode_map(maps:to_list(Map), Opts).
 
 do_encode_map([{K, V} | T], Opts) ->
-    [${, key(K, Opts), $:, value(V, Opts) | do_encode_map_loop(T, Opts)];
+    [${, key(K, Opts), $:, value(V, Opts), do_encode_map_loop(T, Opts)];
 do_encode_map([], _) ->
     <<"{}">>.
 
 do_encode_map_loop([{K, V} | T], Opts) ->
-    [$,, key(K, Opts), $:, value(V, Opts) | do_encode_map_loop(T, Opts)];
+    [$,, key(K, Opts), $:, value(V, Opts), do_encode_map_loop(T, Opts)];
 do_encode_map_loop([], _Opts) ->
-    [$}].
+    $}.
 
 encode_datetime({{YYYY,MM,DD},{H,M,S}}, Opts) ->
     DateTime = iolist_to_binary(io_lib:format(


### PR DESCRIPTION
Close #3 

This PR changes the encode return to `ok | error` tuple to maintain consistency between encode and decode functions.
Also, introduces `specs` and enables `dialyzer` in CI.