### PR TITLE
Bump to v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Like Thoas, both the parser and generator fully conform to
 
 ```erlang
 % rebar.config
-{deps, [{euneus, "0.7.0"}]}
+{deps, [{euneus, "1.0.0"}]}
 ```
 
 ### Elixir
@@ -62,7 +62,7 @@ Like Thoas, both the parser and generator fully conform to
 ```elixir
 # mix.exs
 def deps do
-  [{:euneus, "~> 0.7"}]
+  [{:euneus, "~> 1.0"}]
 end
 ```
 

--- a/src/euneus.app.src
+++ b/src/euneus.app.src
@@ -1,6 +1,6 @@
 {application, euneus, [
     {description, "A JSON parser and generator"},
-    {vsn, "0.7.0"},
+    {vsn, "1.0.0"},
     {registered, []},
     {applications, [
         kernel,


### PR DESCRIPTION
This version deprecates the `datetime_encoder` and the `timestamp_encoder` options in favor of the `datetime` and `timestamp` plugins.