### PR TITLE
Consider proplist a list of key-value pairs

### DIFF
--- a/src/euneus_encoder.erl
+++ b/src/euneus_encoder.erl
@@ -695,19 +695,14 @@ encoder(State) ->
 encode_proplist(Proplist, State) ->
     continue(proplists:to_map(Proplist), State).
 
-is_proplist([]) ->
-    false;
-is_proplist(List) ->
-    lists:all(fun is_proplist_prop/1, List).
-
-% Must be the same types handled by key_to_binary/1.
-is_proplist_prop({Key, _}) ->
+% The key must be of the same type that is handled by key_to_binary/1.
+is_proplist([{Key, _} | _]) ->
     is_binary(Key) orelse
         is_list(Key) orelse
         is_atom(Key) orelse
         is_integer(Key);
-is_proplist_prop(Key) ->
-    is_atom(Key).
+is_proplist(_List) ->
+    false.
 
 encode_sort_keys_map(Map, #state{sort_keys = true} = State) ->
     do_encode_map([

--- a/test/euneus_encoder_SUITE.erl
+++ b/test/euneus_encoder_SUITE.erl
@@ -225,45 +225,20 @@ sort_keys_test(Config) when is_list(Config) ->
         )
     ].
 
--if(?OTP_RELEASE >= 26).
 proplists_test(Config) when is_list(Config) ->
     [
         ?assertEqual(<<"[]">>, encode([], #{proplists => true})),
+        ?assertEqual(<<"[\"foo\",\"bar\"]">>, encode([foo, bar], #{proplists => true})),
+        ?assertEqual(<<"{\"foo\":\"bar\"}">>, encode([{<<"foo">>, bar}], #{proplists => true})),
+        ?assertEqual(<<"{\"foo\":\"bar\"}">>, encode([{"foo", bar}], #{proplists => true})),
+        ?assertEqual(<<"{\"foo\":\"bar\"}">>, encode([{foo, bar}], #{proplists => true})),
+        ?assertEqual(<<"{\"0\":0}">>, encode([{0, 0}], #{proplists => true})),
+        ?assertEqual(<<"[]">>, encode([], #{proplists => {true, fun(_) -> false end}})),
         ?assertEqual(
-            <<"[null,{\"0\":0,\"foo\":\"bar\",\"baz\":true}]">>,
-            encode([null, [{foo, bar}, baz, {0, 0}]], #{proplists => true})
-        ),
-        ?assertEqual(
-            <<"[null,{\"foo\":\"bar\"}]">>,
-            encode([null, [{foo, bar}]], #{
-                proplists =>
-                    {true, fun
-                        ([{_, _}]) -> true;
-                        (_) -> false
-                    end}
-            })
+            <<"{\"foo\":\"bar\"}">>,
+            encode([{foo, bar}], #{proplists => {true, fun([{_, _}]) -> true end}})
         )
     ].
--else.
-proplists_test(Config) when is_list(Config) ->
-    [
-        ?assertEqual(<<"[]">>, encode([], #{proplists => true})),
-        ?assertEqual(
-            <<"[null,{\"foo\":\"bar\",\"baz\":true,\"0\":0}]">>,
-            encode([null, [{foo, bar}, baz, {0, 0}]], #{proplists => true})
-        ),
-        ?assertEqual(
-            <<"[null,{\"foo\":\"bar\"}]">>,
-            encode([null, [{foo, bar}]], #{
-                proplists =>
-                    {true, fun
-                        ([{_, _}]) -> true;
-                        (_) -> false
-                    end}
-            })
-        )
-    ].
--endif.
 
 escape_test(Config) when is_list(Config) ->
     ?assertEqual(<<"bar">>, encode(foo, #{escape => fun(_) -> <<"bar">> end})).


### PR DESCRIPTION
# Description

The actual logic considers an atom of the list as a key-value pair of `{atom(), true}`. This Is valid in Erlang but is potentially buggy because a list of atoms will be considered a proplist. The proplist that contains atoms can be normalized via [lists:unfold/1](https://www.erlang.org/doc/apps/stdlib/proplists.html#unfold/1) before the encoding.

A brief description of your changes.

Closes #&lt;issue&gt;.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/williamthome/euneus/blob/main/CONTRIBUTING.md)
